### PR TITLE
Bring back mouse middle key paste when mouse browsing is disabled

### DIFF
--- a/src/view/telnetview.cpp
+++ b/src/view/telnetview.cpp
@@ -451,7 +451,10 @@ void CTelnetView::OnMouseScroll(GdkEventScroll* evt)
 void CTelnetView::OnMButtonDown(GdkEventButton* evt)
 {
 	if ( AppConfig.MouseSupport != true )
+	{
+		PasteFromClipboard(true);
 		return;
+	}
 
 	if ( AppConfig.WithMiddleButton != true )
 		return;


### PR DESCRIPTION
舊版的pcmanx可以按滑鼠中鍵paste滑鼠剪貼簿內的文字。新版overwrite 掉CTermView的OnMButtonDown()，而沒有把CTermView::OnMButtonDown() paste的部份實作進去。此commit是把CTermView::OnMButtonDown()裏面的實作重複一份到CTelenetView::OnMButtonDown()。
