### PR TITLE
Add checking function on autogen.sh and view/telnetcon.cpp to support mac os.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -18,7 +18,11 @@ fi
 
 ${ACLOCAL:-aclocal$AM_VERSION} ${ACLOCAL_ARG}
 ${AUTOHEADER:-autoheader$AC_VERSION}
-AUTOMAKE=${AUTOMAKE:-automake$AM_VERSION} libtoolize -c --automake
+if [ "`uname`" = "Darwin" ]; then
+    AUTOMAKE=${AUTOMAKE:-automake$AM_VERSION} glibtoolize -c --automake --force
+else
+    AUTOMAKE=${AUTOMAKE:-automake$AM_VERSION} libtoolize -c --automake
+fi
 AUTOMAKE=${AUTOMAKE:-automake$AM_VERSION} intltoolize -c --automake --force
 ${AUTOMAKE:-automake$AM_VERSION} --add-missing --copy --include-deps
 ${AUTOCONF:-autoconf$AC_VERSION}

--- a/src/view/telnetcon.cpp
+++ b/src/view/telnetcon.cpp
@@ -86,7 +86,13 @@
 #if defined(USING_FREEBSD) || defined(CSRG_BASED)
 #include <sys/ioctl.h>
 #include <termios.h>
+
+#ifdef __APPLE__ && __MACH__
+#include <util.h>
+#else
 #include <libutil.h>
+#endif
+
 #endif
 
 #ifdef USE_PROXY


### PR DESCRIPTION
I face a problem when I try to build "pcmanx" on my macbook, but now is ok. Here is my result, add checking function on autogen.sh and view/telnetcon.cpp.