### PR TITLE
fix error while escaping hex code

### DIFF
--- a/src/core/stringutil.cpp
+++ b/src/core/stringutil.cpp
@@ -21,7 +21,6 @@
 #include "stringutil.h"
 #include <cctype>
 #include <cstdio>
-#include <regex.h>
 
 // Note by PCMan:
 // EscapeStr() & UnEscapeStr() :

--- a/src/core/stringutil.cpp
+++ b/src/core/stringutil.cpp
@@ -21,6 +21,7 @@
 #include "stringutil.h"
 #include <cctype>
 #include <cstdio>
+#include <regex.h>
 
 // Note by PCMan:
 // EscapeStr() & UnEscapeStr() :
@@ -72,10 +73,11 @@ string UnEscapeStr(const char* pstr)
 				_str += '^';
 				break;
 			default:	//	\x?? means a hexadecimal integer. ex: \x0d = '\r' and \x0a = '\n'
-				char hex[4];
+				char hex[4] = {pstr[2], pstr[3], '\0', '\0'};
 				int val;
 				sscanf(hex, "%2x", &val);
 				_str += (char)val;
+				pstr += 3;
 				continue;
 			}
 		}
@@ -89,7 +91,10 @@ string UnEscapeStr(const char* pstr)
 				continue;
 			}
 		}
-		_str += *pstr;
+		else
+		{
+			_str += *pstr;
+		}
 	}
 	return _str;
 }


### PR DESCRIPTION
In stringutil, there is a bug while escaping hex (e.g. "\x41")
Because char hex[4] is not initialize.