### PR TITLE
Strip the title if its length is larger than 20 characters.

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -318,6 +318,14 @@ CTelnetCon* CMainFrame::NewCon(string title, string url, CSite* site )
 	m_pView->m_CharPaddingX = AppConfig.CharPaddingX;
 	m_pView->m_CharPaddingY = AppConfig.CharPaddingY;
 
+	/**
+	*	Strip title if its length larger than 20 characters
+	*/
+	if(title.length() > 20){
+        string temp(title, 0, 16);
+        title = temp + "...";
+    }
+
 	pCon->m_Site.m_Name = title;
 	pCon->m_Site.m_URL = url;
 	pCon->m_Encoding = pCon->m_Site.m_Encoding;

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -319,7 +319,7 @@ CTelnetCon* CMainFrame::NewCon(string title, string url, CSite* site )
 	m_pView->m_CharPaddingY = AppConfig.CharPaddingY;
 
 	/**
-	*	Strip title if its length larger than 20 characters
+	*	Shrink title if its length is longer than 20 characters
 	*/
 	if(title.length() > 20){
         string temp(title, 0, 16);

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -319,11 +319,7 @@ CTelnetCon* CMainFrame::NewCon(string title, string url, CSite* site )
 	m_pView->m_CharPaddingY = AppConfig.CharPaddingY;
 
 	/**
-<<<<<<< HEAD
-	*	Shrink title if its length is longer than 20 characters
-=======
-	*	Strip title if its length larger than 20 characters
->>>>>>> 295ee84f304a8b16ba5b83b18faef348bc80d8f4
+	Shrink the title if its length is longer than 20 characters.
 	*/
 	if(title.length() > 20){
         string temp(title, 0, 16);


### PR DESCRIPTION
If the title of an opened tab is too long, it will not be shown
within a tab. Instead, it shows all the characters of the title
and mess with the other tab title. Please see the following
picture for a better problem description.

http://i.imgur.com/MPPosvb.png

This commit first checks if the the length of a title is longer
than 20 characters. If so, it will shrink the title into 17
characters and add '...' at the end, 20 characters in total.

http://i.imgur.com/k8VggEN.png