### PR TITLE
fix reversed selection when pasting

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -991,7 +991,7 @@ void CMainFrame::pasteFromClipboard(GtkMenuItem* pMenuItem UNUSED, CMainFrame* p
 {
 	CTelnetView* t_pView = pMainFrame->GetCurView();
 	if (t_pView != NULL)
-		t_pView->PasteFromClipboard(true);
+		t_pView->PasteFromClipboard(false);
 }
 
 void CMainFrame::OnCloseSelectCon(GtkWidget *notebook, GtkMenuItem* mitem, CMainFrame* _this)
@@ -1126,7 +1126,7 @@ void CMainFrame::OnLastCon(GtkMenuItem* mitem UNUSED, CMainFrame* _this)
 void CMainFrame::OnPaste(GtkMenuItem* mitem UNUSED, CMainFrame* _this)
 {
 	if(_this->GetCurView())
-		_this->GetCurView()->PasteFromClipboard(false);
+		_this->GetCurView()->PasteFromClipboard(true);
 }
 
 void CMainFrame::OnDownArticle(GtkMenuItem* mitem UNUSED, CMainFrame* _this)


### PR DESCRIPTION
let the "Paste" button in context menu paste PRIMARY selection,
and "Paste from Clipboard" button paste CLIPBOARD selection.