### PR TITLE
Fix right-click popup menu only works on current tab

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1347,9 +1347,40 @@ gboolean CMainFrame::OnNotebookPopupMenu(GtkWidget *widget,
 		return TRUE;
 	}
 
-	// if not right check the mouse
-	if (event->type != GDK_BUTTON_PRESS || event->button != 3)
-	        return FALSE;
+    // if right click, switch to the tab first
+    if (event->type == GDK_BUTTON_PRESS && event->button == 3) {
+        int window_w = 0;
+        int window_h = 0;
+        gtk_window_get_size(GTK_WINDOW(gtk_widget_get_toplevel(widget)), &window_w, &window_h);
+
+        int closet_tab_x = window_w;
+        int number_of_pages = gtk_notebook_get_n_pages(GTK_NOTEBOOK(widget));
+        int nth_page_number = 0;
+        int number_of_closet_tab = 0;
+        // pick up the tab which is closet to the click location.
+        for(nth_page_number = 0; nth_page_number < number_of_pages; nth_page_number++)
+        {
+            GtkWidget *tab_label;
+            tab_label = gtk_notebook_get_tab_label(  GTK_NOTEBOOK(widget),
+                gtk_notebook_get_nth_page(GTK_NOTEBOOK(widget),
+                nth_page_number));
+            int lx, ly;
+            gtk_widget_get_pointer(tab_label, &lx, &ly);
+            if(lx > 0 && lx < closet_tab_x)
+            {
+                closet_tab_x = lx;
+                number_of_closet_tab = nth_page_number;
+            }
+        }
+
+        // switch to the page which is clicked.
+        gtk_notebook_set_current_page(GTK_NOTEBOOK(widget), number_of_closet_tab);
+        _this->SetCurView( _this->m_Views[number_of_closet_tab] );
+    } else {
+        // if not right chick the mouse
+        return FALSE;
+    }
+    
 
 	// popup
 	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL,

--- a/src/mainframe.h
+++ b/src/mainframe.h
@@ -68,6 +68,7 @@ public:
 	static void OnShortcutList(GtkMenuItem* mitem, CMainFrame* _this);
 	static void pasteFromClipboard(GtkMenuItem* mitem, CMainFrame* _this);
 	static void OnCloseSelectCon(GtkWidget* notebook, GtkMenuItem* mitem, CMainFrame* _this);
+	static void OnPopupMenuSelectCon(GtkWidget *widget, GtkWidget* menu, GdkEventButton* event, CMainFrame* _this);
 	static void OnCloseCon(GtkMenuItem* mitem, CMainFrame* _this);
 	static void OnCopy(GtkMenuItem* mitem, CMainFrame* _this);
 	static void OnCopyWithColor(GtkMenuItem* mitem, CMainFrame* _this);
@@ -106,6 +107,7 @@ public:
 	bool IsActivated(){	return gtk_window_is_active(GTK_WINDOW(m_Widget));	}
 	static gboolean OnURLEntryKeyDown(GtkWidget *widget,GdkEventKey *evt, CMainFrame* _this);
 	int GetViewIndex(CTermView* view);
+	int GetNearestTab(GtkWidget *widget, GdkEventButton *event);
 	void SwitchToCon(CTelnetCon* con);
 
 	vector<CTelnetView*> m_Views;


### PR DESCRIPTION
fix the issue #44

If users right-click on the tab, pcmanx would swtiches to the tab
first and pops up the menu.
It behaves like CMainFrame::OnCloseSelectCon (mouse middle click).

However, it wouldn't switch back to the original tab when user
selects "close" in the popup menu. Because we can't ensure which
one would be chosen.