### PR TITLE
Enable UAO 2.50 by default

### DIFF
--- a/src/core/site.cpp
+++ b/src/core/site.cpp
@@ -88,7 +88,7 @@ CSite::CSite(string Name)
 	m_bVerticalCenterAlign = true;
 
     // UAO support
-    m_UAO = 0; // 0 = disable, 1 = UAO 2.41, 2 = UAO 2.50
+    m_UAO = 2; // 0 = disable, 1 = UAO 2.41, 2 = UAO 2.50
 
 	m_MenuItem = NULL;
 

--- a/src/sitepage.cpp
+++ b/src/sitepage.cpp
@@ -250,11 +250,11 @@ CSitePage::CSitePage(CSite& site)
     GtkTreeStore* store = gtk_tree_store_new (1, G_TYPE_STRING);
 	GtkTreeIter iter;
 	gtk_tree_store_append (store, &iter, NULL);
+        gtk_tree_store_set (store, &iter, 0, _("2.50"), -1);
+	gtk_tree_store_append (store, &iter, NULL);
+        gtk_tree_store_set (store, &iter, 0, _("2.41"), -1);
+	gtk_tree_store_append (store, &iter, NULL);
 	gtk_tree_store_set (store, &iter, 0, _("Disable"), -1);
-	gtk_tree_store_append (store, &iter, NULL);
-	gtk_tree_store_set (store, &iter, 0, _("2.41"), -1);
-	gtk_tree_store_append (store, &iter, NULL);
-	gtk_tree_store_set (store, &iter, 0, _("2.50"), -1);
 	m_UAOModel = GTK_TREE_MODEL(store);
 	m_UAOBox = gtk_combo_box_new_with_model (m_UAOModel);
 	gtk_box_pack_start(GTK_BOX(uao_box), m_UAOBox, FALSE, FALSE, 0);


### PR DESCRIPTION
Enable UAO 2.50 by default to make some Simplified Chinese
characters, Traditional Chinese characters, and Japanese
characters display normally.