### PR TITLE
Fix the code that incorrectly trim URL.

### DIFF
--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -285,9 +285,9 @@ CTelnetCon* CMainFrame::NewCon(string title, string url, CSite* site )
 		url = url.substr(first, last - first + 1);
 
 	/* Remove telnet:// from url */
-	first = url.find_first_not_of("telnet://");
-	if (first != string::npos)
-		url.erase(0, first);
+	const string telnetPrefix = "telnet://";
+	if(url.substr(0, telnetPrefix.size()) == telnetPrefix)
+		url.erase(0, telnetPrefix.size());
 
 	if ( site == NULL )
 		site = &AppConfig.m_DefaultSite;


### PR DESCRIPTION
url.find_first_not_of("telnet://") is wrong.
Any prefix that contain characters in {'t', 'e', 'l', 'n', ':', '/'} will be removed.
For example, "eod.tw" will be trimmed to "od.tw"