### PR TITLE
Only update .pcmanx/pcmanx and .pcmanx/favorites when needed. Fix #86.

### DIFF
--- a/src/core/site.cpp
+++ b/src/core/site.cpp
@@ -87,8 +87,8 @@ CSite::CSite(string Name)
 	m_bHorizontalCenterAlign = true;
 	m_bVerticalCenterAlign = true;
 
-    // UAO support
-    m_UAO = 2; // 0 = disable, 1 = UAO 2.41, 2 = UAO 2.50
+	// UAO support
+	m_UAO = 2; // 0 = disable, 1 = UAO 2.41, 2 = UAO 2.50
 
 	m_MenuItem = NULL;
 
@@ -105,7 +105,6 @@ CSite::CSite(string Name)
 CSite::~CSite()
 {
 }
-
 
 void CSite::SaveToFile(FILE *fo)
 {
@@ -173,4 +172,85 @@ void CSite::SaveToFile(FILE *fo)
 #endif
 }
 
+bool CSite::compare_to(const CSite &rhs)
+{
+	if( m_Name != rhs.m_Name ) {
+		return false;
+	}
+	if( m_URL != rhs.m_URL )
+		return false;
+	if( m_AutoReconnect != rhs.m_AutoReconnect )
+		return false;
+	if( m_AntiIdle != rhs.m_AntiIdle )
+		return false;
+	if( m_AntiIdleStr != rhs.m_AntiIdleStr )
+		return false;
+	if( m_Encoding != rhs.m_Encoding )
+		return false;
+	if( m_DetectDBChar != rhs.m_DetectDBChar )
+		return false;
+	if( m_RowsPerPage != rhs.m_RowsPerPage )
+		return false;
+	if( m_ColsPerPage != rhs.m_ColsPerPage )
+		return false;
+	if( m_TermType != rhs.m_TermType )
+		return false;
+	if( m_ESCConv != rhs.m_ESCConv )
+		return false;
+	if( m_CRLF != rhs.m_CRLF )
+		return false;
+	if( m_Startup != rhs.m_Startup )
+		return false;
+#ifdef USE_EXTERNAL
+	if( m_UseExternalSSH != rhs.m_UseExternalSSH )
+		return false;
+	if( m_UseExternalTelnet != rhs.m_UseExternalTelnet )
+		return false;
+#endif
+	if( m_bHorizontalCenterAlign != rhs.m_bHorizontalCenterAlign )
+		return false;
+	if( m_bVerticalCenterAlign != rhs.m_bVerticalCenterAlign )
+		return false;
+	if( m_UAO != rhs.m_UAO )
+		return false;
+	if( m_PreLoginPrompt != rhs.m_PreLoginPrompt )
+		return false;
+	if( m_PreLogin != rhs.m_PreLogin )
+		return false;
+	if( m_PostLogin != rhs.m_PostLogin )
+		return false;
+	if( m_LoginPrompt != rhs.m_LoginPrompt )
+		return false;
+	if( m_Login != rhs.m_Login )
+		return false;
+	if( m_PasswdPrompt != rhs.m_PasswdPrompt )
+		return false;
+	if( m_Passwd != rhs.m_Passwd )
+		return false;
+#ifdef USE_PROXY
+	if( m_ProxyType != rhs.m_ProxyType )
+		return false;
+	if( m_ProxyAddr != rhs.m_ProxyAddr )
+		return false;
+	if( m_ProxyPort != rhs.m_ProxyPort )
+		return false;
+	if( m_ProxyUser != rhs.m_ProxyUser )
+		return false;
+	if( m_ProxyPass != rhs.m_ProxyPass )
+		return false;
+#endif
 
+	return true;
+}
+
+bool operator==(const CSite &lhs, const CSite &rhs)
+{
+	CSite site(lhs);
+	return site.compare_to(rhs)? true: false;
+}
+
+bool operator!=(const CSite &lhs, const CSite &rhs)
+{
+	CSite site(lhs);
+	return site.compare_to(rhs)? false: true;
+}

--- a/src/core/site.h
+++ b/src/core/site.h
@@ -79,7 +79,7 @@ public:
 	string m_TermType;
 
 	int m_CRLF;
-    GtkWidget*  m_MenuItem;
+	GtkWidget*  m_MenuItem;
 	// Send CR, LF, or CRLF when Enter is pressed
 	const char* GetCRLF()
 	{
@@ -96,7 +96,7 @@ public:
 	bool m_bHorizontalCenterAlign;
 	bool m_bVerticalCenterAlign;
 
-    int m_UAO;
+	int m_UAO;
 
 #ifdef USE_PROXY
 	// Proxy settings
@@ -131,13 +131,17 @@ public:
 	X_EXPORT string& GetPostLogin(){	return m_PostLogin;	}
 	X_EXPORT void SetPostLogin(string postlogin){	m_PostLogin = postlogin;	}
 
+	X_EXPORT bool compare_to(const CSite &rhs);
+	friend bool operator==(const CSite &lhs, const CSite &rhs);
+	friend bool operator!=(const CSite &lhs, const CSite &rhs);
+
 protected:
-    string m_Passwd;
-    string m_Login;
-    string m_LoginPrompt;
-    string m_PasswdPrompt;
-    string m_PreLogin;
-    string m_PreLoginPrompt;
+	string m_Passwd;
+	string m_Login;
+	string m_LoginPrompt;
+	string m_PasswdPrompt;
+	string m_PreLogin;
+	string m_PreLoginPrompt;
 	string m_PostLogin;
 };
 

--- a/src/editfavdlg.h
+++ b/src/editfavdlg.h
@@ -36,18 +36,18 @@ class CListBox;
 class CEditFavDlg : public CDialog
 {
 public:
-    CEditFavDlg(CWidget* parent, vector<CSite>& sites);
+	CEditFavDlg(CWidget* parent, vector<CSite>& sites);
 
-    static void OnAdd(GtkWidget* btn, CEditFavDlg* _this);
-    static void OnEdit(GtkWidget* btn, CEditFavDlg* _this);
-    static void OnRemove(GtkWidget* btn, CEditFavDlg* _this);
-    static void OnUp(GtkWidget* btn, CEditFavDlg* _this);
-    static void OnDown(GtkWidget* btn, CEditFavDlg* _this);
-    static void OnRowActivated(GtkTreeView *tree_view, GtkTreePath* path,  
+	static void OnAdd(GtkWidget* btn, CEditFavDlg* _this);
+	static void OnEdit(GtkWidget* btn, CEditFavDlg* _this);
+	static void OnRemove(GtkWidget* btn, CEditFavDlg* _this);
+	static void OnUp(GtkWidget* btn, CEditFavDlg* _this);
+	static void OnDown(GtkWidget* btn, CEditFavDlg* _this);
+	static void OnRowActivated(GtkTreeView *tree_view, GtkTreePath* path,
 	GtkTreeViewColumn* col, CEditFavDlg* _this);
 
-	vector<CSite>& m_Sites;
-    CListBox* m_List;
+	vector<CSite> m_Sites;
+	CListBox* m_List;
 	GtkWidget* m_EditBtn;
 protected:
 };

--- a/src/generalprefpage.cpp
+++ b/src/generalprefpage.cpp
@@ -183,23 +183,62 @@ CGeneralPrefPage::CGeneralPrefPage()
 }
 
 
-void CGeneralPrefPage::OnOK()
+bool CGeneralPrefPage::OnOK()
 {
-	AppConfig.QueryOnCloseCon = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_QueryOnCloseCon));
-	AppConfig.QueryOnExit = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_QueryOnExit));
-	AppConfig.CancelSelAfterCopy = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_CancelSelAfterCopy));
-  AppConfig.Opacity = (int) gtk_adjustment_get_value(GTK_ADJUSTMENT(m_Opacity_adj));
+	bool pref_updated = false;
+
+	if( AppConfig.QueryOnCloseCon != gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_QueryOnCloseCon)) ) {
+		pref_updated = true;
+		AppConfig.QueryOnCloseCon = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_QueryOnCloseCon));
+	}
+	if( AppConfig.QueryOnExit != gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_QueryOnExit)) ) {
+		pref_updated = true;
+		AppConfig.QueryOnExit = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_QueryOnExit));
+	}
+	if( AppConfig.CancelSelAfterCopy != gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_CancelSelAfterCopy)) ) {
+		pref_updated = true;
+		AppConfig.CancelSelAfterCopy = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_CancelSelAfterCopy));
+	}
+	if( AppConfig.Opacity != (int) gtk_adjustment_get_value(GTK_ADJUSTMENT(m_Opacity_adj)) ) {
+		pref_updated = true;
+		AppConfig.Opacity = (int) gtk_adjustment_get_value(GTK_ADJUSTMENT(m_Opacity_adj));
+	}
 #ifdef USE_MOUSE
-	AppConfig.MouseSupport = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_MouseSupport));
+	if( AppConfig.MouseSupport != gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_MouseSupport)) ) {
+		pref_updated = true;
+		AppConfig.MouseSupport = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_MouseSupport));
+	}
 #endif
 #ifdef USE_DOCKLET
-	AppConfig.ShowTrayIcon = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_ShowTrayIcon));
+	if( AppConfig.ShowTrayIcon != gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_ShowTrayIcon)) ) {
+		pref_updated = true;
+		AppConfig.ShowTrayIcon = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_ShowTrayIcon));
+	}
 #endif
-	AppConfig.AntiAliasFont = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_AAFont));
-	AppConfig.PopupNotifier =  gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(m_PopupNotifier));
-	AppConfig.PopupTimeout = (int)gtk_spin_button_get_value( GTK_SPIN_BUTTON(m_PopupTimeout));
-	AppConfig.MidClickAsClose = gtk_toggle_button_get_active(
-			GTK_TOGGLE_BUTTON(m_MidClickAsClose));
-	AppConfig.WebBrowser = gtk_entry_get_text(GTK_ENTRY(m_WebBrowser));
-	AppConfig.MailClient = gtk_entry_get_text(GTK_ENTRY(m_MailClient));
+	if( AppConfig.AntiAliasFont != gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_AAFont)) ) {
+		pref_updated = true;
+		AppConfig.AntiAliasFont = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_AAFont));
+	}
+	if( AppConfig.PopupNotifier != gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_PopupNotifier)) ) {
+		pref_updated = true;
+		AppConfig.PopupNotifier = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_PopupNotifier));
+	}
+	if( AppConfig.PopupTimeout != (int)gtk_spin_button_get_value(GTK_SPIN_BUTTON(m_PopupTimeout)) ) {
+		pref_updated = true;
+		AppConfig.PopupTimeout = (int)gtk_spin_button_get_value(GTK_SPIN_BUTTON(m_PopupTimeout));
+	}
+	if( AppConfig.MidClickAsClose != gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_MidClickAsClose)) ) {
+		pref_updated = true;
+		AppConfig.MidClickAsClose = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(m_MidClickAsClose));
+	}
+	if( AppConfig.WebBrowser != gtk_entry_get_text(GTK_ENTRY(m_WebBrowser)) ) {
+		pref_updated = true;
+		AppConfig.WebBrowser = gtk_entry_get_text(GTK_ENTRY(m_WebBrowser));
+	}
+	if( AppConfig.MailClient != gtk_entry_get_text(GTK_ENTRY(m_MailClient)) ) {
+		pref_updated = true;
+		AppConfig.MailClient = gtk_entry_get_text(GTK_ENTRY(m_MailClient));
+	}
+
+	return pref_updated;
 }

--- a/src/generalprefpage.h
+++ b/src/generalprefpage.h
@@ -31,15 +31,15 @@
 class CGeneralPrefPage : public CWidget
 {
 public:
-    CGeneralPrefPage();
-    void OnOK();
+	CGeneralPrefPage();
+	bool OnOK();
 public:
 	GtkWidget *m_QueryOnCloseCon;
 	GtkWidget *m_QueryOnExit;
 	GtkWidget *m_CancelSelAfterCopy;
 
-  GtkWidget *m_Opacity;
-  GtkObject *m_Opacity_adj;
+	GtkWidget *m_Opacity;
+	GtkObject *m_Opacity_adj;
 #ifdef USE_MOUSE
 	GtkWidget *m_MouseSupport;
 #endif
@@ -55,7 +55,6 @@ public:
 	GtkWidget *m_PopupTimeout;
 	GtkWidget *m_MidClickAsClose;
 	GtkWidget *m_pWgetFiles;
-
 };
 
 #endif

--- a/src/keysettingpage.cpp
+++ b/src/keysettingpage.cpp
@@ -116,8 +116,10 @@ CKeySettingPage::CKeySettingPage(GtkWidget *parent): CWidget()
 /**
  * Get value from gtk entries and save them into AppConfig
  */
-void CKeySettingPage::OnOK()
+bool CKeySettingPage::OnOK()
 {
+	bool setting_updated = false;
+
 	// show message dialog
 	GtkWidget *MessageDialog = gtk_message_dialog_new(
 			GTK_WINDOW(m_Parent),
@@ -130,25 +132,84 @@ void CKeySettingPage::OnOK()
 	gtk_dialog_run(GTK_DIALOG(MessageDialog));
 	gtk_widget_destroy(MessageDialog);
 
-	AppConfig.keySiteList = gtk_entry_get_text(GTK_ENTRY(m_Entries[keySiteList]));
-	AppConfig.keyNewConn0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNewConn0]));
-	AppConfig.keyNewConn1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNewConn1]));
-	AppConfig.keyReconn0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyReconn0]));
-	AppConfig.keyReconn1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyReconn1]));
-	AppConfig.keyClose0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyClose0]));
-	AppConfig.keyClose1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyClose1]));
-	AppConfig.keyNextPage = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNextPage]));
-	AppConfig.keyPrevPage = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPrevPage]));
-	AppConfig.keyFirstPage = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyFirstPage]));
-	AppConfig.keyLastPage = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyLastPage]));
-	AppConfig.keyCopy0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyCopy0]));
-	AppConfig.keyCopy1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyCopy1]));
-	AppConfig.keyPaste0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPaste0]));
-	AppConfig.keyPaste1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPaste1]));
-	AppConfig.keyPasteClipboard = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPasteClipboard]));
-	AppConfig.keyEmotions = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyEmotions]));
-	AppConfig.keyFullscreen = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyFullscreen]));
-	AppConfig.keyShowMainWindow = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyShowMainWindow]));
+	if( AppConfig.keySiteList != gtk_entry_get_text(GTK_ENTRY(m_Entries[keySiteList])) ) {
+		setting_updated = true;
+		AppConfig.keySiteList = gtk_entry_get_text(GTK_ENTRY(m_Entries[keySiteList]));
+	}
+	if( AppConfig.keyNewConn0 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNewConn0])) ) {
+		setting_updated = true;
+		AppConfig.keyNewConn0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNewConn0]));
+	}
+	if( AppConfig.keyNewConn1 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNewConn1])) ) {
+		setting_updated = true;
+		AppConfig.keyNewConn1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNewConn1]));
+	}
+	if( AppConfig.keyReconn0 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyReconn0])) ) {
+		setting_updated = true;
+		AppConfig.keyReconn0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyReconn0]));
+	}
+	if( AppConfig.keyReconn1 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyReconn1])) ) {
+		setting_updated = true;
+		AppConfig.keyReconn1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyReconn1]));
+	}
+	if( AppConfig.keyClose0 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyClose0])) ) {
+		setting_updated = true;
+		AppConfig.keyClose0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyClose0]));
+	}
+	if( AppConfig.keyClose1 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyClose1])) ) {
+		setting_updated = true;
+		AppConfig.keyClose1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyClose1]));
+	}
+	if( AppConfig.keyNextPage != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNextPage])) ) {
+		setting_updated = true;
+		AppConfig.keyNextPage = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyNextPage]));
+	}
+	if( AppConfig.keyPrevPage != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPrevPage])) ) {
+		setting_updated = true;
+		AppConfig.keyPrevPage = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPrevPage]));
+	}
+	if( AppConfig.keyFirstPage != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyFirstPage])) ) {
+		setting_updated = true;
+		AppConfig.keyFirstPage = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyFirstPage]));
+	}
+	if( AppConfig.keyLastPage != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyLastPage])) ) {
+		setting_updated = true;
+		AppConfig.keyLastPage = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyLastPage]));
+	}
+	if( AppConfig.keyCopy0 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyCopy0])) ) {
+		setting_updated = true;
+		AppConfig.keyCopy0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyCopy0]));
+	}
+	if( AppConfig.keyCopy1 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyCopy1])) ) {
+		setting_updated = true;
+		AppConfig.keyCopy1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyCopy1]));
+	}
+	if( AppConfig.keyPaste0 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPaste0])) ) {
+		setting_updated = true;
+		AppConfig.keyPaste0 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPaste0]));
+	}
+	if( AppConfig.keyPaste1 != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPaste1])) ) {
+		setting_updated = true;
+		AppConfig.keyPaste1 = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPaste1]));
+	}
+	if( AppConfig.keyPasteClipboard != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPasteClipboard])) ) {
+		setting_updated = true;
+		AppConfig.keyPasteClipboard = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyPasteClipboard]));
+	}
+	if( AppConfig.keyEmotions != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyEmotions])) ) {
+		setting_updated = true;
+		AppConfig.keyEmotions = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyEmotions]));
+	}
+	if( AppConfig.keyFullscreen != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyFullscreen])) ) {
+		setting_updated = true;
+		AppConfig.keyFullscreen = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyFullscreen]));
+	}
+	if( AppConfig.keyShowMainWindow != gtk_entry_get_text(GTK_ENTRY(m_Entries[keyShowMainWindow])) ) {
+		setting_updated = true;
+		AppConfig.keyShowMainWindow = gtk_entry_get_text(GTK_ENTRY(m_Entries[keyShowMainWindow]));
+	}
+
+	return setting_updated;
 }
 
 gboolean CKeySettingPage::onKeyPress(GtkWidget *widget, GdkEventKey *event, gpointer data)

--- a/src/keysettingpage.h
+++ b/src/keysettingpage.h
@@ -34,7 +34,7 @@ class CKeySettingPage: public CWidget
 {
 public:
 	CKeySettingPage(GtkWidget *parent);
-	void OnOK();
+	bool OnOK();
 public:
 	enum KeyNames {
 		keySiteList, keyNewConn0, keyNewConn1, keyReconn0, keyReconn1,

--- a/src/mainframe.cpp
+++ b/src/mainframe.cpp
@@ -1552,8 +1552,10 @@ void CMainFrame::OnEditFavorites(GtkMenuItem* widget UNUSED, CMainFrame* _this)
 {
 	CEditFavDlg* dlg = new CEditFavDlg(_this, AppConfig.Favorites);
 	dlg->ShowModal();
-	AppConfig.Favorites.swap(dlg->m_Sites);
-	AppConfig.SaveFavorites();
+	if( AppConfig.Favorites != dlg->m_Sites ) {
+		AppConfig.Favorites.swap(dlg->m_Sites);
+		AppConfig.SaveFavorites();
+	}
 	dlg->Destroy();
 
 	_this->CreateFavoritesMenu();

--- a/src/pcmanx_gtk2.cpp
+++ b/src/pcmanx_gtk2.cpp
@@ -195,7 +195,6 @@ int main(int argc, char *argv[])
 #endif
 	CTelnetCon::Cleanup();
 
-	AppConfig.SaveFavorites();
 	AppConfig.Save();
 
 	lt_dlexit();

--- a/src/pcmanx_gtk2.cpp
+++ b/src/pcmanx_gtk2.cpp
@@ -195,8 +195,6 @@ int main(int argc, char *argv[])
 #endif
 	CTelnetCon::Cleanup();
 
-	AppConfig.Save();
-
 	lt_dlexit();
 
 	return 0;

--- a/src/prefdlg.cpp
+++ b/src/prefdlg.cpp
@@ -53,10 +53,22 @@ bool CPrefDlg::OnOK()
 {
 	if( m_pSitePage->OnOK() )
 	{
-		AppConfig.m_DefaultSite = m_pSitePage->m_Site;
-		m_pGeneralPrefPage->OnOK();
-		m_pKeySettingPage->OnOK();
-		AppConfig.Save();
+		bool pref_updated = false;
+
+		if( AppConfig.m_DefaultSite != m_pSitePage->m_Site ) {
+			pref_updated = true;
+			AppConfig.m_DefaultSite = m_pSitePage->m_Site;
+		}
+		if( m_pGeneralPrefPage->OnOK() ) {
+			pref_updated = true;
+		}
+		if( m_pKeySettingPage->OnOK() ) {
+			pref_updated = true;
+		}
+
+		if( pref_updated ) {
+			AppConfig.Save();
+		}
 	}
 	return true;
 }

--- a/src/prefdlg.h
+++ b/src/prefdlg.h
@@ -36,12 +36,12 @@ class CKeySettingPage;
 class CPrefDlg : public CDialog
 {
 public:
-    CPrefDlg(CWidget* parent);
-    bool OnOK();
+	CPrefDlg(CWidget* parent);
+	bool OnOK();
 
 public:
-    CSitePage* m_pSitePage;
-    CNotebook* m_pNotebook;
+	CSitePage* m_pSitePage;
+	CNotebook* m_pNotebook;
 	CGeneralPrefPage* m_pGeneralPrefPage;
 	CKeySettingPage *m_pKeySettingPage;
 };


### PR DESCRIPTION
This PR fixes the issue #86.

As-is: 
1). Always write configurations to the file whenever the program is going to close.
2). Always write favorites to the file whenever the program is going to close.

To-be:
1). Remove the call of AppConfig.Save() on exit. Add checks to configurations before saving.
2). Remove the call of SaveFavorites() on exit. Add a check to compare favorites lists before saving in the callback OnEditFavorites().