### PR TITLE
Fix crash inside `CTelnetView::OnRButtonDown`

### DIFF
--- a/src/view/telnetview.cpp
+++ b/src/view/telnetview.cpp
@@ -628,8 +628,10 @@ void CTelnetView::OnRButtonDown(GdkEventButton* evt)
 	gtk_menu_item_set_submenu (GTK_MENU_ITEM (input_menu_item), submenu);
 
 	// Show Web Search only when text selected
-	if(websearch_menu_item)
+	if(websearch_menu_item) {
 		gtk_widget_destroy(websearch_menu_item);
+		websearch_menu_item = NULL;
+	}
 	string selected_text = m_pTermData->GetSelectedText(false);
 	if(! selected_text.empty()) {
 		gsize wl = 0;


### PR DESCRIPTION
Set websearch_menu_item to NULL after calling gtk_widget_destroy to avoid double free

Steps to reproduce the crash:
1. Select some text
2. Open context menu
3. Deselect text
4. Open context menu twice after deselect