### PR TITLE
Get rid of Host key authentiction can't be established messge

### DIFF
--- a/src/view/telnetcon.cpp
+++ b/src/view/telnetcon.cpp
@@ -320,7 +320,7 @@ bool CTelnetCon::Connect()
 		{
 			// Child Process;
 			close(m_SockFD);
-			execlp ( prog, prog, address.c_str(), NULL ) ;
+			execlp ( prog, prog, "-o StrictHostKeyChecking=no", address.c_str(), NULL ) ;
 			exit(EXIT_FAILURE);
 		}
 		else


### PR DESCRIPTION
This patch can get rid of the follow message:
```
The authenticity of host 'ptt.cc (140.112.172.1)' can't be established.
ECDSA key fingerprint is SHA256:3rvcAywUJszX7jPzC3JkbtxqnHiApB4tuwQ3swSYmSo.
Are you sure you want to continue connecting (yes/no)?
```
when connecting to a BBS in the ssh mode.
This message is usually of no harm in the PCMAX use case (viewing BBS sites).
So skip it.