### PR TITLE
Let regenerated libtoolize file overwrite existing file in other environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
 before_install:
     - sudo apt-get update -qq
-    - sudo apt-get install -qq intltool libgtk2.0-dev libnotify-dev libx11-dev libltdl-dev
+    - sudo apt-get install -qq intltool libgtk2.0-dev libnotify-dev libx11-dev libltdl-dev autopoint
 
 script:
     - ./autogen.sh

--- a/autogen.sh
+++ b/autogen.sh
@@ -12,19 +12,7 @@ if [ ! -e ChangeLog ]; then
   fi
 fi
 
-if [ "x${ACLOCAL_DIR}" != "x" ]; then
-  ACLOCAL_ARG=-I ${ACLOCAL_DIR}
-fi
-
-${ACLOCAL:-aclocal$AM_VERSION} ${ACLOCAL_ARG}
-${AUTOHEADER:-autoheader$AC_VERSION}
-if [ "`uname`" = "Darwin" ]; then
-    AUTOMAKE=${AUTOMAKE:-automake$AM_VERSION} glibtoolize -c --automake --force
-else
-    AUTOMAKE=${AUTOMAKE:-automake$AM_VERSION} libtoolize -c --automake
-fi
+autoreconf --install --force
 AUTOMAKE=${AUTOMAKE:-automake$AM_VERSION} intltoolize -c --automake --force
-${AUTOMAKE:-automake$AM_VERSION} --add-missing --copy --include-deps
-${AUTOCONF:-autoconf$AC_VERSION}
 
 rm -rf autom4te.cache


### PR DESCRIPTION
For resolving error message after run `./autogen.sh` again after run it before, in order to revise autotool settings and test again.


```
$ ./autogen.sh 
+ '[' '!' -e ChangeLog ']'
+ '[' x '!=' x ']'
+ aclocal
+ autoheader
++ uname
+ '[' Linux = Darwin ']'
+ AUTOMAKE=automake
+ libtoolize -c --automake
libtoolize:   error: './compile' exists: use '--force' to overwrite
libtoolize:   error: './depcomp' exists: use '--force' to overwrite
libtoolize:   error: './missing' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/COPYING.LIB' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/Makefile.am' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/README' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/configure.ac' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/aclocal.m4' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/Makefile.in' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/config-h.in' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/configure' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt__alloc.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt__argz_.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt__dirent.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt__glibc.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt__private.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt__strl.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt_dlloader.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt_error.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/lt_system.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/libltdl/slist.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/loaders/dld_link.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/loaders/dlopen.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/loaders/dyld.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/loaders/load_add_on.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/loaders/loadlibrary.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/loaders/preopen.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/loaders/shl_load.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/lt__alloc.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/lt__argz.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/lt__dirent.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/lt__strl.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/lt_dlloader.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/lt_error.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/ltdl.c' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/ltdl.h' exists: use '--force' to overwrite
libtoolize:   error: 'libltdl/slist.c' exists: use '--force' to overwrite…ronment
```

tested environments:
* libtool: 2.4.6
* autoconf: 2.69
* aclocal: 1.16.1
* bash: 5.0.7
* gcc: 9.2.1
* Distribution: Fedora 31 beta