### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,21 @@ matrix:
         - env: CONFIGURE="--disable-external"
         - env: CONFIGURE="--enable-iplookup"
         - env: CONFIGURE="--enable-proxy"
+#Added power jobs
+        - env: CONFIGURE=""
+          arch: ppc64le
+        - env: CONFIGURE="--enable-debug"
+          arch: ppc64le
+        - env: CONFIGURE="--disable-nancy"
+          arch: ppc64le
+        - env: CONFIGURE="--disable-mouse"
+          arch: ppc64le
+        - env: CONFIGURE="--disable-external"
+          arch: ppc64le
+        - env: CONFIGURE="--enable-iplookup"
+          arch: ppc64le
+        - env: CONFIGURE="--enable-proxy"
+          arch: ppc64le
 
 before_install:
     - sudo apt-get update -qq


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.